### PR TITLE
Change cal_data output string format

### DIFF
--- a/source/bme280.cpp
+++ b/source/bme280.cpp
@@ -251,7 +251,7 @@ int BME280::logPartBSensorCal(std::ofstream & ofile)
   //
   // Write Cal data to ofile
   //
-  ofile << "Sensor ID [" << std::hex << (int)uniqueID << "] Calibration Data ||" ;
+  ofile << "Sensor ID [" << std::hex << (int)uniqueID << "] Calibration Data :" ;
   {
     // uint8_t *ptr = (void *) cal_data;
     for (unsigned int i = 0 ; i < sizeof(cal_data) ; i++)
@@ -259,8 +259,8 @@ int BME280::logPartBSensorCal(std::ofstream & ofile)
       ofile << std::hex << std::setfill('0') << std::setw(2) << (int)cal_data.compArray[i];
     }
   }
-  ofile << "||" << std::endl ;
     
+  ofile << std::endl ;
   // ofile << "||" << std::endl << "-----" << std::endl;
  
   return 0;

--- a/source/bme280.cpp
+++ b/source/bme280.cpp
@@ -251,7 +251,7 @@ int BME280::logPartBSensorCal(std::ofstream & ofile)
   //
   // Write Cal data to ofile
   //
-  ofile << "Sensor ID [" << std::hex << (int)uniqueID << "] Calibration Data :" ;
+  ofile << "Sensor ID [" << std::hex << (int)uniqueID << "] Calibration Data : " ;
   {
     // uint8_t *ptr = (void *) cal_data;
     for (unsigned int i = 0 ; i < sizeof(cal_data) ; i++)


### PR DESCRIPTION
BME280.cpp now outputs cal_data string to display the calibration string in the same format as the other parts of the header. 

This will simplify the code that parses the data found within this file. 

As I do not have a test bench, I cannot confirm that the code functions properly, we will need to perform a test before we can confirm that this works.